### PR TITLE
Add docblocks to the facade

### DIFF
--- a/src/Facades/CrowdOx.php
+++ b/src/Facades/CrowdOx.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \edh649\CrowdOx\Resources\States states()
  * @method static \edh649\CrowdOx\Resources\Projects projects()
  * @method static \edh649\CrowdOx\Resources\ProductVariations product_variations()
- * @method static \edh649\CrowdOx\Resources\OrderTransactions order_trgetValidResourcesansactions()
+ * @method static \edh649\CrowdOx\Resources\OrderTransactions order_transactions()
  * @method static \edh649\CrowdOx\Resources\OrderTags order_tags()
  * @method static \edh649\CrowdOx\Resources\OrderSelections order_selections()
  * @method static \edh649\CrowdOx\Resources\Orders orders()

--- a/src/Facades/CrowdOx.php
+++ b/src/Facades/CrowdOx.php
@@ -2,6 +2,21 @@
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static void freshClient() Create a fresh client instance
+ * @method static \edh649\CrowdOx\Resources\States states()
+ * @method static \edh649\CrowdOx\Resources\Projects projects()
+ * @method static \edh649\CrowdOx\Resources\ProductVariations product_variations()
+ * @method static \edh649\CrowdOx\Resources\OrderTransactions order_trgetValidResourcesansactions()
+ * @method static \edh649\CrowdOx\Resources\OrderTags order_tags()
+ * @method static \edh649\CrowdOx\Resources\OrderSelections order_selections()
+ * @method static \edh649\CrowdOx\Resources\Orders orders()
+ * @method static \edh649\CrowdOx\Resources\OrderLines order_lines()
+ * @method static \edh649\CrowdOx\Resources\OrderAddresses order_addresses()
+ * @method static \edh649\CrowdOx\Resources\Customers customers()
+ * @method static \edh649\CrowdOx\Resources\Countries countries()
+ * @method static \edh649\CrowdOx\Resources\Products products()
+ */
 class CrowdOx extends Facade {
 
     /**

--- a/src/Facades/CrowdOx.php
+++ b/src/Facades/CrowdOx.php
@@ -4,18 +4,18 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static void freshClient() Create a fresh client instance
- * @method static \edh649\CrowdOx\Resources\States states()
- * @method static \edh649\CrowdOx\Resources\Projects projects()
- * @method static \edh649\CrowdOx\Resources\ProductVariations product_variations()
- * @method static \edh649\CrowdOx\Resources\OrderTransactions order_transactions()
- * @method static \edh649\CrowdOx\Resources\OrderTags order_tags()
- * @method static \edh649\CrowdOx\Resources\OrderSelections order_selections()
- * @method static \edh649\CrowdOx\Resources\Orders orders()
- * @method static \edh649\CrowdOx\Resources\OrderLines order_lines()
- * @method static \edh649\CrowdOx\Resources\OrderAddresses order_addresses()
- * @method static \edh649\CrowdOx\Resources\Customers customers()
- * @method static \edh649\CrowdOx\Resources\Countries countries()
- * @method static \edh649\CrowdOx\Resources\Products products()
+ * @method static \edh649\CrowdOx\Resources\States states(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\Projects projects(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\ProductVariations product_variations(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\OrderTransactions order_transactions(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\OrderTags order_tags(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\OrderSelections order_selections(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\Orders orders(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\OrderLines order_lines(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\OrderAddresses order_addresses(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\Customers customers(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\Countries countries(string|int $resource_id = null)
+ * @method static \edh649\CrowdOx\Resources\Products products(string|int $resource_id = null)
  */
 class CrowdOx extends Facade {
 


### PR DESCRIPTION
This package gave several phpstan errors around things like `CrowdOx::orders()`, since the `orders` method uses a magic method to access it. I've just added docblocks for all the methods the facade can use so it's clear to phpstan the calls are valid.